### PR TITLE
Python3.5 backwards support in string formatting

### DIFF
--- a/argparse_addons.py
+++ b/argparse_addons.py
@@ -16,15 +16,15 @@ class Integer:
         if self.minimum is not None and self.maximum is not None:
             if not self.minimum <= value <= self.maximum:
                 raise argparse.ArgumentTypeError(
-                    f'{string} is not in the range {self.minimum}..{self.maximum}')
+                    '{} is not in the range {}..{}'.format(string, self.minimum, self.maximum))
         elif self.minimum is not None:
             if value < self.minimum:
                 raise argparse.ArgumentTypeError(
-                    f'{string} is not in the range {self.minimum}..inf')
+                    '{} is not in the range {}..inf'.format(string, self.minimum))
         elif self.maximum is not None:
             if value > self.maximum:
                 raise argparse.ArgumentTypeError(
-                    f'{string} is not in the range -inf..{self.maximum}')
+                    '{} is not in the range -inf..{}'.format(string, self.maximum))
 
         return value
 


### PR DESCRIPTION
I came across the "inconvenience" of argparse_addons not being python 3.5 compatible due to the string formatting.
Indeed I know, it is very outdated, however, I am stuck to Ubuntu 16.04 LTS (which is still supported).

As argparse_addons is a dependency of cantools, which I in turn depend on, it breaks my pip installation of it.

Please consider the "rollback" to python 3.5 for edge cases such as these.

All the best and keep up the good work!

Signed-off-by: jenszo <github@jenszo.de>